### PR TITLE
Add matchers for 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ describe('Response', function() {
 |toPassNotFound()|The response has a not found status code.|
 |toPassForbidden()|The response has a forbidden status code.|
 |toPassUnauthorized()|The response has an unauthorized status code.|
+|toPassCreated()|The response has a 201 status code.
+|toPassNoContent(_$status_ = 204)|The response has the given status code and no content.
 |toPassStatus(_$status_)|The response has the given status code.|
 |toPassRedirect(_$uri_ = null)|The response is redirecting to a given URI.|
 |toPassHeader(_$headerName_, _$value_ = null)|The response contains the given header and equals the optional value.|
@@ -156,6 +158,7 @@ describe('Response', function() {
 |toPassJsonFragment(array _$data_)|The response contains the given JSON fragment.|
 |toPassJsonMissing(array _$data_, _$exact_ = false)|The response does not contain the given JSON fragment.|
 |toPassJsonMissingExact(array _$data_)|The response does not contain the exact JSON fragment.|
+|toPassJsonPath(_$path_, _$expect_, _$strict_ = false)|The expected value exists at the given path in the response.
 |toPassJsonStructure(array _$structure_ = null, _$responseData_ = null)|The response has a given JSON structure.|
 |toPassJsonCount(int _$count_, _$key_ = null)|The response JSON has the expected count of items at the given key.|
 |toPassJsonValidationErrors(_$errors_)|The response has the given JSON validation errors.|

--- a/src/Matcher/ToPassCreated.php
+++ b/src/Matcher/ToPassCreated.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace LaravelKahlan4\Matcher;
+
+use Illuminate\Foundation\Testing\TestResponse;
+
+class ToPassCreated extends BaseMatcher
+{
+    static function match(TestResponse $response)
+    {
+        static::buildDescription(
+            'pass assertCreated().'
+        );
+
+        return static::assert(function() use ($response) {
+            $response->assertCreated();
+        });
+    }
+}
+

--- a/src/Matcher/ToPassJsonPath.php
+++ b/src/Matcher/ToPassJsonPath.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LaravelKahlan4\Matcher;
+
+use Illuminate\Foundation\Testing\TestResponse;
+
+class ToPassJsonPath extends BaseMatcher
+{
+    static function match(TestResponse $response, $path, $expect, $strict = false)
+    {
+        static::buildDescription(
+            'pass assertJsonPath().',
+            compact('path', 'expect', 'strict')
+        );
+
+        return static::assert(function() use ($response, $path, $expect, $strict) {
+            $response->assertJsonPath($path, $expect, $strict);
+        });
+    }
+}
+

--- a/src/Matcher/ToPassNoContent.php
+++ b/src/Matcher/ToPassNoContent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LaravelKahlan4\Matcher;
+
+use Illuminate\Foundation\Testing\TestResponse;
+
+class ToPassNoContent extends BaseMatcher
+{
+    static function match(TestResponse $response, $status = 204)
+    {
+        static::buildDescription(
+            'pass assertNoContent().',
+            compact('status')
+        );
+
+        return static::assert(function() use ($response, $status) {
+            $response->assertNoContent($status);
+        });
+    }
+}
+

--- a/test-project/spec/Matcher.spec.php
+++ b/test-project/spec/Matcher.spec.php
@@ -50,6 +50,21 @@ describe('Matcher', function() {
             });
         });
 
+        describe('toPassCreated', function() {
+            it('calls assertCreated()', function() {
+                expect($this->response)->toPassCreated();
+                $this->response->shouldHaveReceived()->assertCreated();
+            });
+        });
+
+        describe('toPassNoContent', function() {
+            it('calls assertNoContent()', function() {
+                expect($this->response)->toPassNoContent(204);
+                $this->response->shouldHaveReceived()->assertNoContent(204);
+            });
+        });
+
+
         describe('toPassStatus', function() {
             it('calls assertStatus()', function() {
                 expect($this->response)->toPassStatus(200);
@@ -194,6 +209,13 @@ describe('Matcher', function() {
             it('calls assertJsonMissingExact()', function() {
                 expect($this->response)->toPassJsonMissingExact([]);
                 $this->response->shouldHaveReceived()->assertJsonMissingExact([]);
+            });
+        });
+
+        describe('toPassJsonPath', function() {
+            it('calls assertJsonPath()', function() {
+                expect($this->response)->toPassJsonPath('path', [], false);
+                $this->response->shouldHaveReceived()->assertJsonPath('path', [], false);
             });
         });
 


### PR DESCRIPTION
Hi!
I've added matchers for 6.x.

- toPassJsonPath (from [6.0.4](https://github.com/laravel/framework/blob/6.x/CHANGELOG-6.x.md#v604-2019-09-24))
- toPassNoContent (from [6.1.0](https://github.com/laravel/framework/blob/6.x/CHANGELOG-6.x.md#v610-2019-10-01))
- toPassCreated (from [6.4.0](https://github.com/laravel/framework/blob/6.x/CHANGELOG-6.x.md#v640-2019-10-23))

Regards.