### PR TITLE
Support laravel 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "laravel/framework": "^6.0",
+        "laravel/framework": "^6.0 || ^7.0",
         "kahlan/kahlan": "^4.6"
     },
     "autoload": {

--- a/src/Matcher/BaseMatcher.php
+++ b/src/Matcher/BaseMatcher.php
@@ -2,6 +2,7 @@
 
 namespace LaravelKahlan4\Matcher;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\ExpectationFailedException;
 
 abstract class BaseMatcher
@@ -28,5 +29,15 @@ abstract class BaseMatcher
         }
 
         return true;
+    }
+
+    protected static function ensureValidResponse($response)
+    {
+        if (
+            !$response instanceof \Illuminate\Foundation\Testing\TestResponse  // 6.x
+            && !$response instanceof \Illuminate\Testing\TestResponse          // 7.x
+        ) {
+            throw new InvalidArgumentException('Response must be an instance of \Illuminate\Foundation\Testing\TestResponse or \Illuminate\Testing\TestResponse.');
+        }
     }
 }

--- a/src/Matcher/ToPassCookie.php
+++ b/src/Matcher/ToPassCookie.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassCookie extends BaseMatcher
 {
-    static function match(TestResponse $response, $cookieName, $value=null, $encrypted=true, $unserialize=false)
+    static function match($response, $cookieName, $value=null, $encrypted=true, $unserialize=false)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertCookie().',
             compact('cookieName', 'value', 'encrypted', 'unserialize')

--- a/src/Matcher/ToPassCookieExpired.php
+++ b/src/Matcher/ToPassCookieExpired.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassCookieExpired extends BaseMatcher
 {
-    static function match(TestResponse $response, $cookieName)
+    static function match($response, $cookieName)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertCookieExpired().',
             compact('cookieName')

--- a/src/Matcher/ToPassCookieMissing.php
+++ b/src/Matcher/ToPassCookieMissing.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassCookieMissing extends BaseMatcher
 {
-    static function match(TestResponse $response, $cookieName)
+    static function match($response, $cookieName)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertCookieMissing().',
             compact('cookieName')

--- a/src/Matcher/ToPassCookieNotExpired.php
+++ b/src/Matcher/ToPassCookieNotExpired.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassCookieNotExpired extends BaseMatcher
 {
-    static function match(TestResponse $response, $cookieName)
+    static function match($response, $cookieName)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertCookieNotExpired().',
             compact('cookieName')

--- a/src/Matcher/ToPassCreated.php
+++ b/src/Matcher/ToPassCreated.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassCreated extends BaseMatcher
 {
-    static function match(TestResponse $response)
+    static function match($response)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertCreated().'
         );

--- a/src/Matcher/ToPassDontSee.php
+++ b/src/Matcher/ToPassDontSee.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassDontSee extends BaseMatcher
 {
-    static function match(TestResponse $response, $value)
+    static function match($response, $value)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertDontSee().',
             compact('value')

--- a/src/Matcher/ToPassDontSeeText.php
+++ b/src/Matcher/ToPassDontSeeText.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassDontSeeText extends BaseMatcher
 {
-    static function match(TestResponse $response, $value)
+    static function match($response, $value)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertDontSeeText().',
             compact('value')

--- a/src/Matcher/ToPassExactJson.php
+++ b/src/Matcher/ToPassExactJson.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassExactJson extends BaseMatcher
 {
-    static function match(TestResponse $response, array $data)
+    static function match($response, array $data)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertExactJson().',
             compact('data')

--- a/src/Matcher/ToPassForbidden.php
+++ b/src/Matcher/ToPassForbidden.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassForbidden extends BaseMatcher
 {
-    static function match(TestResponse $response)
+    static function match($response)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertForbidden().'
         );

--- a/src/Matcher/ToPassHeader.php
+++ b/src/Matcher/ToPassHeader.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassHeader extends BaseMatcher
 {
-    static function match(TestResponse $response, $headerName, $value=null)
+    static function match($response, $headerName, $value=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertHeader().',
             compact('headerName', 'value')

--- a/src/Matcher/ToPassHeaderMissing.php
+++ b/src/Matcher/ToPassHeaderMissing.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassHeaderMissing extends BaseMatcher
 {
-    static function match(TestResponse $response, $headerName)
+    static function match($response, $headerName)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertHeaderMissing().',
             compact('headerName')

--- a/src/Matcher/ToPassJson.php
+++ b/src/Matcher/ToPassJson.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJson extends BaseMatcher
 {
-    static function match(TestResponse $response, array $data, $strict=false)
+    static function match($response, array $data, $strict=false)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJson().',
             compact('data', 'strict')

--- a/src/Matcher/ToPassJsonCount.php
+++ b/src/Matcher/ToPassJsonCount.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJsonCount extends BaseMatcher
 {
-    static function match(TestResponse $response, int $count, $key=null)
+    static function match($response, int $count, $key=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJsonCount().',
             compact('count', 'key')

--- a/src/Matcher/ToPassJsonFragment.php
+++ b/src/Matcher/ToPassJsonFragment.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJsonFragment extends BaseMatcher
 {
-    static function match(TestResponse $response, array $data)
+    static function match($response, array $data)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJsonFragment().',
             compact('data')

--- a/src/Matcher/ToPassJsonMissing.php
+++ b/src/Matcher/ToPassJsonMissing.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJsonMissing extends BaseMatcher
 {
-    static function match(TestResponse $response, array $data, $exact=false)
+    static function match($response, array $data, $exact=false)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJsonMissing().',
             compact('data', 'exact')

--- a/src/Matcher/ToPassJsonMissingExact.php
+++ b/src/Matcher/ToPassJsonMissingExact.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJsonMissingExact extends BaseMatcher
 {
-    static function match(TestResponse $response, array $data)
+    static function match($response, array $data)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJsonMissingExact().',
             compact('data')

--- a/src/Matcher/ToPassJsonMissingValidationErrors.php
+++ b/src/Matcher/ToPassJsonMissingValidationErrors.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJsonMissingValidationErrors extends BaseMatcher
 {
-    static function match(TestResponse $response, $keys=null)
+    static function match($response, $keys=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJsonMissingValidationErrors().',
             compact('keys')

--- a/src/Matcher/ToPassJsonPath.php
+++ b/src/Matcher/ToPassJsonPath.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJsonPath extends BaseMatcher
 {
-    static function match(TestResponse $response, $path, $expect, $strict = false)
+    static function match($response, $path, $expect, $strict = false)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJsonPath().',
             compact('path', 'expect', 'strict')

--- a/src/Matcher/ToPassJsonStructure.php
+++ b/src/Matcher/ToPassJsonStructure.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJsonStructure extends BaseMatcher
 {
-    static function match(TestResponse $response, array $structure=null, $responseData=null)
+    static function match($response, array $structure=null, $responseData=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJsonStructure().',
             compact('structure', 'responseData')

--- a/src/Matcher/ToPassJsonValidationErrors.php
+++ b/src/Matcher/ToPassJsonValidationErrors.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassJsonValidationErrors extends BaseMatcher
 {
-    static function match(TestResponse $response, $errors)
+    static function match($response, $errors)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertJsonValidationErrors().',
             compact('errors')

--- a/src/Matcher/ToPassLocation.php
+++ b/src/Matcher/ToPassLocation.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassLocation extends BaseMatcher
 {
-    static function match(TestResponse $response, $uri)
+    static function match($response, $uri)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertLocation().',
             compact('uri')

--- a/src/Matcher/ToPassNoContent.php
+++ b/src/Matcher/ToPassNoContent.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassNoContent extends BaseMatcher
 {
-    static function match(TestResponse $response, $status = 204)
+    static function match($response, $status = 204)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertNoContent().',
             compact('status')

--- a/src/Matcher/ToPassNotFound.php
+++ b/src/Matcher/ToPassNotFound.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassNotFound extends BaseMatcher
 {
-    static function match(TestResponse $response)
+    static function match($response)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertNotFound().'
         );

--- a/src/Matcher/ToPassOk.php
+++ b/src/Matcher/ToPassOk.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassOk extends BaseMatcher
 {
-    static function match(TestResponse $response)
+    static function match($response)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertOk().'
         );

--- a/src/Matcher/ToPassPlainCookie.php
+++ b/src/Matcher/ToPassPlainCookie.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassPlainCookie extends BaseMatcher
 {
-    static function match(TestResponse $response, $cookieName, $value=null)
+    static function match($response, $cookieName, $value=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertPlainCookie().',
             compact('cookieName', 'value')

--- a/src/Matcher/ToPassRedirect.php
+++ b/src/Matcher/ToPassRedirect.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassRedirect extends BaseMatcher
 {
-    static function match(TestResponse $response, $uri=null)
+    static function match($response, $uri=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertRedirect().',
             compact('uri')

--- a/src/Matcher/ToPassSee.php
+++ b/src/Matcher/ToPassSee.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSee extends BaseMatcher
 {
-    static function match(TestResponse $response, $value)
+    static function match($response, $value)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSee().',
             compact('value')

--- a/src/Matcher/ToPassSeeInOrder.php
+++ b/src/Matcher/ToPassSeeInOrder.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSeeInOrder extends BaseMatcher
 {
-    static function match(TestResponse $response, array $values)
+    static function match($response, array $values)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSeeInOrder().',
             compact('values')

--- a/src/Matcher/ToPassSeeText.php
+++ b/src/Matcher/ToPassSeeText.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSeeText extends BaseMatcher
 {
-    static function match(TestResponse $response, $value)
+    static function match($response, $value)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'be passed assertSeeText().',
             compact('value')

--- a/src/Matcher/ToPassSeeTextInOrder.php
+++ b/src/Matcher/ToPassSeeTextInOrder.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSeeTextInOrder extends BaseMatcher
 {
-    static function match(TestResponse $response, array $values)
+    static function match($response, array $values)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSeeTextInOrder().',
             compact('values')

--- a/src/Matcher/ToPassSessionDoesntHaveErrors.php
+++ b/src/Matcher/ToPassSessionDoesntHaveErrors.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSessionDoesntHaveErrors extends BaseMatcher
 {
-    static function match(TestResponse $response, $keys=[], $format=null, $errorBag='default')
+    static function match($response, $keys=[], $format=null, $errorBag='default')
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSessionDoesntHaveErrors().',
             compact('keys', 'format', 'errorBag')

--- a/src/Matcher/ToPassSessionHas.php
+++ b/src/Matcher/ToPassSessionHas.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSessionHas extends BaseMatcher
 {
-    static function match(TestResponse $response, $key, $value=null)
+    static function match($response, $key, $value=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSessionHas().',
             compact('key', 'value')

--- a/src/Matcher/ToPassSessionHasAll.php
+++ b/src/Matcher/ToPassSessionHasAll.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSessionHasAll extends BaseMatcher
 {
-    static function match(TestResponse $response, array $bindings)
+    static function match($response, array $bindings)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSessionHasAll().',
             compact('bindings')

--- a/src/Matcher/ToPassSessionHasErrors.php
+++ b/src/Matcher/ToPassSessionHasErrors.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSessionHasErrors extends BaseMatcher
 {
-    static function match(TestResponse $response, $keys=[], $format=null, $errorBag='default')
+    static function match($response, $keys=[], $format=null, $errorBag='default')
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSessionHasErrors().',
             compact('keys', 'format', 'errorBag')

--- a/src/Matcher/ToPassSessionHasErrorsIn.php
+++ b/src/Matcher/ToPassSessionHasErrorsIn.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSessionHasErrorsIn extends BaseMatcher
 {
-    static function match(TestResponse $response, $errorBag, $keys=[], $format=null)
+    static function match($response, $errorBag, $keys=[], $format=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSessionHasErrorsIn().',
             compact('errorBag', 'keys', 'format')

--- a/src/Matcher/ToPassSessionHasInput.php
+++ b/src/Matcher/ToPassSessionHasInput.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSessionHasInput extends BaseMatcher
 {
-    static function match(TestResponse $response, $key, $value=null)
+    static function match($response, $key, $value=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSessionHasInput().',
             compact('key', 'value')

--- a/src/Matcher/ToPassSessionHasNoErrors.php
+++ b/src/Matcher/ToPassSessionHasNoErrors.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSessionHasNoErrors extends BaseMatcher
 {
-    static function match(TestResponse $response)
+    static function match($response)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSessionHasNoErrors().'
         );

--- a/src/Matcher/ToPassSessionMissing.php
+++ b/src/Matcher/ToPassSessionMissing.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSessionMissing extends BaseMatcher
 {
-    static function match(TestResponse $response, $key)
+    static function match($response, $key)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSessionMissing().',
             compact('key')

--- a/src/Matcher/ToPassStatus.php
+++ b/src/Matcher/ToPassStatus.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassStatus extends BaseMatcher
 {
-    static function match(TestResponse $response, $status)
+    static function match($response, $status)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertStatus().',
             compact('status')

--- a/src/Matcher/ToPassSuccessful.php
+++ b/src/Matcher/ToPassSuccessful.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassSuccessful extends BaseMatcher
 {
-    static function match(TestResponse $response)
+    static function match($response)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertSuccessful().'
         );

--- a/src/Matcher/ToPassUnauthorized.php
+++ b/src/Matcher/ToPassUnauthorized.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassUnauthorized extends BaseMatcher
 {
-    static function match(TestResponse $response)
+    static function match($response)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertUnauthorized().'
         );

--- a/src/Matcher/ToPassViewHas.php
+++ b/src/Matcher/ToPassViewHas.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassViewHas extends BaseMatcher
 {
-    static function match(TestResponse $response, $key, $value=null)
+    static function match($response, $key, $value=null)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertViewHas().',
             compact('key', 'value')

--- a/src/Matcher/ToPassViewHasAll.php
+++ b/src/Matcher/ToPassViewHasAll.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassViewHasAll extends BaseMatcher
 {
-    static function match(TestResponse $response, array $bindings)
+    static function match($response, array $bindings)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertViewHasAll().',
             compact('bindings')

--- a/src/Matcher/ToPassViewIs.php
+++ b/src/Matcher/ToPassViewIs.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassViewIs extends BaseMatcher
 {
-    static function match(TestResponse $response, $value)
+    static function match($response, $value)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertViewIs().',
             compact('value')

--- a/src/Matcher/ToPassViewMissing.php
+++ b/src/Matcher/ToPassViewMissing.php
@@ -2,12 +2,12 @@
 
 namespace LaravelKahlan4\Matcher;
 
-use Illuminate\Foundation\Testing\TestResponse;
-
 class ToPassViewMissing extends BaseMatcher
 {
-    static function match(TestResponse $response, $key)
+    static function match($response, $key)
     {
+        static::ensureValidResponse($response);
+
         static::buildDescription(
             'pass assertViewMissing().',
             compact('key')


### PR DESCRIPTION
Hi.
I added support for laravel 7.x.

Because of [this](https://laravel.com/docs/7.x/upgrade#test-response), I dropped `TestResponse` type hint.

I've upgraded laravel in test-project to 7.x and confirmed tests have passed.
```
$ php test-project/artisan -V
Laravel Framework 7.8.1
$ composer test
> cd test-project && ./vendor/bin/kahlan
            _     _
  /\ /\__ _| |__ | | __ _ _ __
 / //_/ _` | '_ \| |/ _` | '_ \
/ __ \ (_| | | | | | (_| | | | |
\/  \/\__,_|_| |_|_|\__,_|_| |_|

The PHP Test Framework for Freedom, Truth and Justice.

src directory  :
spec directory : /tmp/laravel-kahlan4/test-project/spec

................................................................. 65 / 69 ( 94%)
....                                                              69 / 69 (100%)



Expectations   : 69 Executed
Specifications : 0 Pending, 0 Excluded, 0 Skipped

Passed 69 of 69 PASS in 0.895 seconds (using 43MB)
```

Regards.