### PR TITLE
Support laravel 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "laravel/framework": "^6.0 || ^7.0",
+        "laravel/framework": "^6.0 || ^7.0 || ^8.0",
         "kahlan/kahlan": "^4.6"
     },
     "autoload": {

--- a/test-project/spec/Laravel.spec.php
+++ b/test-project/spec/Laravel.spec.php
@@ -23,7 +23,11 @@ describe('Laravel', function() {
     });
 
     it('works authentication test', function() {
-        $user = factory(App\User::class)->make();
+        if (version_compare(app()->version(), '8.0.0', '<')) {
+            $user = factory(App\User::class)->make();
+        } else {
+            $user = App\Models\User::factory()->make();
+        }
         $this->laravel->actingAs($user);
         expect($this->laravel)->toPassAuthenticated();
     });
@@ -42,7 +46,11 @@ describe('Laravel', function() {
         });
 
         it('works database test', function() {
-            $user = factory(App\User::class)->create();
+            if (version_compare(app()->version(), '8.0.0', '<')) {
+                $user = factory(App\User::class)->create();
+            } else {
+                $user = App\Models\User::factory()->create();
+            }
             expect($this->laravel)->toPassDatabaseHas('users', ['email' => $user['email']]);
         });
     });


### PR DESCRIPTION
Hi.
This PR adds support for laravel 8.x.

[Model factories feature](https://laravel.com/docs/8.x/upgrade#model-factories) is not compatible with 7.x, so I use `version_compare`.

I've tested v8.0.4 in other directory.

```shell
$ php test-project/artisan -V
Laravel Framework 7.28.1
$ composer test
> cd test-project && ./vendor/bin/kahlan
            _     _
  /\ /\__ _| |__ | | __ _ _ __
 / //_/ _` | '_ \| |/ _` | '_ \
/ __ \ (_| | | | | | (_| | | | |
\/  \/\__,_|_| |_|_|\__,_|_| |_|

The PHP Test Framework for Freedom, Truth and Justice.

src directory  :
spec directory : /tmp/laravel-kahlan4/test-project/spec

................................................................. 65 / 69 ( 94%)
....                                                              69 / 69 (100%)



Expectations   : 69 Executed
Specifications : 0 Pending, 0 Excluded, 0 Skipped

Passed 69 of 69 PASS in 1.093 seconds (using 44MB)
$ php laravel8/artisan -V
Laravel Framework 8.0.4
$ cd laravel8/ && ./vendor/bin/kahlan
            _     _
  /\ /\__ _| |__ | | __ _ _ __
 / //_/ _` | '_ \| |/ _` | '_ \
/ __ \ (_| | | | | | (_| | | | |
\/  \/\__,_|_| |_|_|\__,_|_| |_|

The PHP Test Framework for Freedom, Truth and Justice.

src directory  :
spec directory : /tmp/laravel-kahlan4/laravel8/spec

................................................................. 65 / 69 ( 94%)
....                                                              69 / 69 (100%)



Expectations   : 69 Executed
Specifications : 0 Pending, 0 Excluded, 0 Skipped

Passed 69 of 69 PASS in 1.073 seconds (using 45MB)
```

Thanks.