### PR TITLE
Support laravel 9.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,12 +8,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
-        laravel: [6.*, 7.*, 8.*]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1]
+        laravel: [6.*, 7.*, 8.*, 9.*]
         kahlan: [4.*, 5.*]
         exclude:
+          - php: 8.1
+            laravel: 7.*
+          - php: 8.1
+            laravel: 6.*
+          - php: 8.1
+            kahlan: 4.*
           - php: 8.0
             kahlan: 4.*
+          - php: 7.4
+            laravel: 9.*
+          - php: 7.3
+            laravel: 9.*
+          - php: 7.2
+            laravel: 9.*
           - php: 7.2
             laravel: 8.*
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "laravel/framework": "^6.0 || ^7.0 || ^8.0",
+        "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0",
         "kahlan/kahlan": "^4.6 || ^5.0"
     },
     "autoload": {


### PR DESCRIPTION
Hi!

This PR adds support for laravel 9.x and tests on php 8.1.

- [My test result](https://github.com/gitetsu/laravel-kahlan4/actions/runs/1926837859)
- [Supported Laravel versions](https://laravel.com/docs/9.x/releases#support-policy)
- [Supported PHP versions](https://www.php.net/supported-versions.php)

Maybe we could drop support for older versions like php(<7.4) or Laravel(<8).

Thanks.